### PR TITLE
style: tweaks styles for workflow summary component

### DIFF
--- a/app/dashboard/workflows/[id]/page.tsx
+++ b/app/dashboard/workflows/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function Page({ params }: { params: { id: string } }) {
     <WithLoader loading={isLoading || !workflow}>
       <Container maxWidth={false}>
         <WorkflowViewToolbar></WorkflowViewToolbar>
-        <Box mb="10px">
+        <Box mb="20px">
           <WorkflowSummary wf={workflow!}></WorkflowSummary>
         </Box>
         {workflow && <WorflowRuns workflowID={workflow?.id} />}

--- a/components/workflow-view/summary/summary.tsx
+++ b/components/workflow-view/summary/summary.tsx
@@ -8,19 +8,19 @@ export const WorkflowSummary = ({ wf }: { wf: WorkflowItem }) => {
       <CardContent>
         <Grid container>
           <Grid item xs={3}>
-            <Typography sx={{ fontSize: 14 }}>Name</Typography>
+            <Typography variant="overline">Name</Typography>
             <Typography>{wf.name}</Typography>
           </Grid>
           <Grid item xs={3}>
-            <Typography sx={{ fontSize: 14 }}>Project</Typography>
+            <Typography variant="overline">Project</Typography>
             <Typography>{wf.project}</Typography>
           </Grid>
           <Grid item xs={3}>
-            <Typography sx={{ fontSize: 14 }}>Team</Typography>
+            <Typography variant="overline">Team</Typography>
             <Typography>{wf.team || "none"}</Typography>
           </Grid>
           <Grid item xs={3}>
-            <Typography sx={{ fontSize: 14 }}>Created At</Typography>
+            <Typography variant="overline">Created At</Typography>
             <Typography>{wf.createdAt?.toDateString()}</Typography>
           </Grid>
         </Grid>

--- a/components/workflow-view/toolbar/toolbar.tsx
+++ b/components/workflow-view/toolbar/toolbar.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "@mui/material";
 
 export const WorkflowViewToolbar = () => (
-  <Typography variant="h4">Workflow info</Typography>
+  <Typography variant="h3">Workflow info</Typography>
 );

--- a/theme/index.js
+++ b/theme/index.js
@@ -49,6 +49,7 @@ export const theme = createTheme({
           textTransform: "Capitalize",
         },
         overline: {
+          color: "#374151",
           fontWeight: "600",
           textTransform: "Uppercase",
         },

--- a/theme/index.js
+++ b/theme/index.js
@@ -60,6 +60,13 @@ export const theme = createTheme({
         disableRipple: true,
       },
     },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          boxShadow: 'rgba(17, 17, 26, 0.05) 0px 1px 0px, rgba(17, 17, 26, 0.1) 0px 0px 8px'
+        },
+      },
+    },
     MuiCardContent: {
       styleOverrides: {
         root: {

--- a/theme/index.js
+++ b/theme/index.js
@@ -123,6 +123,29 @@ export const theme = createTheme({
         },
       },
     },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#F3F4F6",
+          ".MuiTableCell-root": {
+            color: "#374151",
+          },
+          borderBottom: "none",
+          "& .MuiTableCell-root": {
+            borderBottom: "none",
+            fontSize: "12px",
+            fontWeight: 600,
+            lineHeight: 1,
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+          },
+          "& .MuiTableCell-paddingCheckbox": {
+            paddingTop: 4,
+            paddingBottom: 4,
+          },
+        },
+      },
+    },
     MuiOutlinedInput: {
       styleOverrides: {
         notchedOutline: {

--- a/theme/index.js
+++ b/theme/index.js
@@ -43,6 +43,17 @@ export const theme = createTheme({
         },
       },
     },
+    MuiTypography: {
+      styleOverrides: {
+        root: {
+          textTransform: "Capitalize",
+        },
+        overline: {
+          fontWeight: "600",
+          textTransform: "Uppercase",
+        },
+      },
+    },
     MuiButtonBase: {
       defaultProps: {
         disableRipple: true,


### PR DESCRIPTION
This PR applies some basic styling for this component, for their labels and values.

![image](https://user-images.githubusercontent.com/13178577/204835464-8a3307b2-35a8-4613-8737-d663c7461301.png)

also, I'm getting back the basic styles for tables. More details about that are in [this comment.](https://github.com/paabloLC/chainloop-dev/commit/7b0d7e3c2b369a0c6e6ae4334c0e701364875af9#r91556275)
