### PR TITLE
chore: add pagination types

### DIFF
--- a/gen/controlplane/v1/pagination.ts
+++ b/gen/controlplane/v1/pagination.ts
@@ -1,0 +1,190 @@
+/* eslint-disable */
+import _m0 from "protobufjs/minimal";
+
+export const protobufPackage = "controlplane.v1";
+
+export interface PaginationResponse {
+  nextCursor: string;
+  prevCursor: string;
+}
+
+export interface PaginationRequest {
+  cursor: string;
+  direction: PaginationRequest_Direction;
+  /** Limit pagination to 100 */
+  limit: number;
+}
+
+/** nolint:ENUM_VALUE_PREFIX */
+export enum PaginationRequest_Direction {
+  DIRECTION_NEXT_PAGE = 0,
+  DIRECTION_PREV_PAGE = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function paginationRequest_DirectionFromJSON(object: any): PaginationRequest_Direction {
+  switch (object) {
+    case 0:
+    case "DIRECTION_NEXT_PAGE":
+      return PaginationRequest_Direction.DIRECTION_NEXT_PAGE;
+    case 1:
+    case "DIRECTION_PREV_PAGE":
+      return PaginationRequest_Direction.DIRECTION_PREV_PAGE;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return PaginationRequest_Direction.UNRECOGNIZED;
+  }
+}
+
+export function paginationRequest_DirectionToJSON(object: PaginationRequest_Direction): string {
+  switch (object) {
+    case PaginationRequest_Direction.DIRECTION_NEXT_PAGE:
+      return "DIRECTION_NEXT_PAGE";
+    case PaginationRequest_Direction.DIRECTION_PREV_PAGE:
+      return "DIRECTION_PREV_PAGE";
+    case PaginationRequest_Direction.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+function createBasePaginationResponse(): PaginationResponse {
+  return { nextCursor: "", prevCursor: "" };
+}
+
+export const PaginationResponse = {
+  encode(message: PaginationResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.nextCursor !== "") {
+      writer.uint32(10).string(message.nextCursor);
+    }
+    if (message.prevCursor !== "") {
+      writer.uint32(18).string(message.prevCursor);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PaginationResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePaginationResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nextCursor = reader.string();
+          break;
+        case 2:
+          message.prevCursor = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PaginationResponse {
+    return {
+      nextCursor: isSet(object.nextCursor) ? String(object.nextCursor) : "",
+      prevCursor: isSet(object.prevCursor) ? String(object.prevCursor) : "",
+    };
+  },
+
+  toJSON(message: PaginationResponse): unknown {
+    const obj: any = {};
+    message.nextCursor !== undefined && (obj.nextCursor = message.nextCursor);
+    message.prevCursor !== undefined && (obj.prevCursor = message.prevCursor);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PaginationResponse>, I>>(object: I): PaginationResponse {
+    const message = createBasePaginationResponse();
+    message.nextCursor = object.nextCursor ?? "";
+    message.prevCursor = object.prevCursor ?? "";
+    return message;
+  },
+};
+
+function createBasePaginationRequest(): PaginationRequest {
+  return { cursor: "", direction: 0, limit: 0 };
+}
+
+export const PaginationRequest = {
+  encode(message: PaginationRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.cursor !== "") {
+      writer.uint32(10).string(message.cursor);
+    }
+    if (message.direction !== 0) {
+      writer.uint32(16).int32(message.direction);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(24).int32(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PaginationRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePaginationRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.cursor = reader.string();
+          break;
+        case 2:
+          message.direction = reader.int32() as any;
+          break;
+        case 3:
+          message.limit = reader.int32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PaginationRequest {
+    return {
+      cursor: isSet(object.cursor) ? String(object.cursor) : "",
+      direction: isSet(object.direction) ? paginationRequest_DirectionFromJSON(object.direction) : 0,
+      limit: isSet(object.limit) ? Number(object.limit) : 0,
+    };
+  },
+
+  toJSON(message: PaginationRequest): unknown {
+    const obj: any = {};
+    message.cursor !== undefined && (obj.cursor = message.cursor);
+    message.direction !== undefined && (obj.direction = paginationRequest_DirectionToJSON(message.direction));
+    message.limit !== undefined && (obj.limit = Math.round(message.limit));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PaginationRequest>, I>>(object: I): PaginationRequest {
+    const message = createBasePaginationRequest();
+    message.cursor = object.cursor ?? "";
+    message.direction = object.direction ?? 0;
+    message.limit = object.limit ?? 0;
+    return message;
+  },
+};
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/gen/controlplane/v1/workflowrun.ts
+++ b/gen/controlplane/v1/workflowrun.ts
@@ -2,6 +2,7 @@
 import { grpc } from "@improbable-eng/grpc-web";
 import { BrowserHeaders } from "browser-headers";
 import _m0 from "protobufjs/minimal";
+import { PaginationRequest, PaginationResponse } from "./pagination";
 import { AttestationItem, WorkflowContractVersionItem, WorkflowItem, WorkflowRunItem } from "./response_messages";
 
 export const protobufPackage = "controlplane.v1";
@@ -96,10 +97,12 @@ export interface AttestationServiceCancelResponse {
 export interface WorkflowRunServiceListRequest {
   /** Filter by workflow */
   workflowId: string;
+  pagination?: PaginationRequest;
 }
 
 export interface WorkflowRunServiceListResponse {
   result: WorkflowRunItem[];
+  pagination?: PaginationResponse;
 }
 
 export interface WorkflowRunServiceViewRequest {
@@ -670,13 +673,16 @@ export const AttestationServiceCancelResponse = {
 };
 
 function createBaseWorkflowRunServiceListRequest(): WorkflowRunServiceListRequest {
-  return { workflowId: "" };
+  return { workflowId: "", pagination: undefined };
 }
 
 export const WorkflowRunServiceListRequest = {
   encode(message: WorkflowRunServiceListRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.workflowId !== "") {
       writer.uint32(10).string(message.workflowId);
+    }
+    if (message.pagination !== undefined) {
+      PaginationRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -691,6 +697,9 @@ export const WorkflowRunServiceListRequest = {
         case 1:
           message.workflowId = reader.string();
           break;
+        case 2:
+          message.pagination = PaginationRequest.decode(reader, reader.uint32());
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -700,12 +709,17 @@ export const WorkflowRunServiceListRequest = {
   },
 
   fromJSON(object: any): WorkflowRunServiceListRequest {
-    return { workflowId: isSet(object.workflowId) ? String(object.workflowId) : "" };
+    return {
+      workflowId: isSet(object.workflowId) ? String(object.workflowId) : "",
+      pagination: isSet(object.pagination) ? PaginationRequest.fromJSON(object.pagination) : undefined,
+    };
   },
 
   toJSON(message: WorkflowRunServiceListRequest): unknown {
     const obj: any = {};
     message.workflowId !== undefined && (obj.workflowId = message.workflowId);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination ? PaginationRequest.toJSON(message.pagination) : undefined);
     return obj;
   },
 
@@ -714,18 +728,24 @@ export const WorkflowRunServiceListRequest = {
   ): WorkflowRunServiceListRequest {
     const message = createBaseWorkflowRunServiceListRequest();
     message.workflowId = object.workflowId ?? "";
+    message.pagination = (object.pagination !== undefined && object.pagination !== null)
+      ? PaginationRequest.fromPartial(object.pagination)
+      : undefined;
     return message;
   },
 };
 
 function createBaseWorkflowRunServiceListResponse(): WorkflowRunServiceListResponse {
-  return { result: [] };
+  return { result: [], pagination: undefined };
 }
 
 export const WorkflowRunServiceListResponse = {
   encode(message: WorkflowRunServiceListResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.result) {
       WorkflowRunItem.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PaginationResponse.encode(message.pagination, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -740,6 +760,9 @@ export const WorkflowRunServiceListResponse = {
         case 1:
           message.result.push(WorkflowRunItem.decode(reader, reader.uint32()));
           break;
+        case 2:
+          message.pagination = PaginationResponse.decode(reader, reader.uint32());
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -749,7 +772,10 @@ export const WorkflowRunServiceListResponse = {
   },
 
   fromJSON(object: any): WorkflowRunServiceListResponse {
-    return { result: Array.isArray(object?.result) ? object.result.map((e: any) => WorkflowRunItem.fromJSON(e)) : [] };
+    return {
+      result: Array.isArray(object?.result) ? object.result.map((e: any) => WorkflowRunItem.fromJSON(e)) : [],
+      pagination: isSet(object.pagination) ? PaginationResponse.fromJSON(object.pagination) : undefined,
+    };
   },
 
   toJSON(message: WorkflowRunServiceListResponse): unknown {
@@ -759,6 +785,8 @@ export const WorkflowRunServiceListResponse = {
     } else {
       obj.result = [];
     }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination ? PaginationResponse.toJSON(message.pagination) : undefined);
     return obj;
   },
 
@@ -767,6 +795,9 @@ export const WorkflowRunServiceListResponse = {
   ): WorkflowRunServiceListResponse {
     const message = createBaseWorkflowRunServiceListResponse();
     message.result = object.result?.map((e) => WorkflowRunItem.fromPartial(e)) || [];
+    message.pagination = (object.pagination !== undefined && object.pagination !== null)
+      ? PaginationResponse.fromPartial(object.pagination)
+      : undefined;
     return message;
   },
 };


### PR DESCRIPTION
ChainLoop [control plane v0.8.35](https://cp.chainloop.dev/infoz) supports cursor based pagination. This patch adds the API types to leverage it for #15 

The new backend pagination supports both previous and next pages using two different cursors returned by the API. The number of items window can be defined via a `limit` option. It has an internal max value of 100 

Just for context, this is how it works in the API and CLI. The UI will need to automatically send the `next|PrevCursor` and set the limit on demand.  

```json
grpcurl -H "authorization: Bearer $TOKEN" -d "{\"pagination\": { \"limit\": 2, \"cursor\": \"${NEXT}\", \"direction\": \"DIRECTION_NEXT_PAGE\" }}"  api.cp.chainloop.dev:443 controlplane.v1.WorkflowRunService.List | jq
{
  "result": [
    {
      "id": "1a01f7b6-b4d8-401a-a9e5-417be97238cb",
      "createdAt": "2022-11-30T15:00:42.844001Z",
      "finishedAt": "2022-11-30T15:01:25.904463Z",
      "state": "success",
      "workflow": {
        "id": "f9e6ee94-283c-44dd-8e7d-8fe5816358cb",
        "name": "build-and-test",
        "project": "bedrock",
        "team": "core",
        "createdAt": "2022-11-03T12:24:09.940949Z",
        "runsCount": 595
      },
      "jobUrl": "https://github.com/chainloop-dev/bedrock/actions/runs/3584456525",
      "runnerType": "GITHUB_ACTION"
    },
    {
      "id": "04523848-dbfb-49ee-ab0a-0bc7865146c9",
      "createdAt": "2022-11-30T15:00:40.297447Z",
      "finishedAt": "2022-11-30T15:03:14.408102Z",
      "state": "success",
      "workflow": {
        "id": "f9e6ee94-283c-44dd-8e7d-8fe5816358cb",
        "name": "build-and-test",
        "project": "bedrock",
        "team": "core",
        "createdAt": "2022-11-03T12:24:09.940949Z",
        "runsCount": 595
      },
      "jobUrl": "https://github.com/chainloop-dev/bedrock/actions/runs/3584456525",
      "runnerType": "GITHUB_ACTION"
    }
  ],
  "pagination": {
    "nextCursor": "MjAyMi0xMS0zMFQxNTowMDo0MC4yOTc0NDdaLDA0NTIzODQ4LWRiZmItNDllZS1hYjBhLTBiYzc4NjUxNDZjOQ==",
    "prevCursor": "MjAyMi0xMS0zMFQxNTowMDo0Mi44NDQwMDFaLDFhMDFmN2I2LWI0ZDgtNDAxYS1hOWU1LTQxN2JlOTcyMzhjYg=="
  }
}
```


![Peek 2022-11-30 16-23](https://user-images.githubusercontent.com/24523/204838142-0adb4966-4de7-4e5d-ba56-5ea41c7861f7.gif)
