### PR TITLE
feat: workflow-runs list

### DIFF
--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -8,13 +8,40 @@ import {
   useWorkflowRunsList,
 } from "@lib/apiclient/workflowRuns";
 import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function WorkflowRunsList() {
   const { apiClient } = useAuth();
-  const [limit, setLimit] = useState(20);
-  const opts: IRunsListOpts = { limit: limit };
+  // Store the cursor associated with the page
+  // Using useref to prevent re-rendering
+  const mapPageToNextCursor = useRef<{ [page: number]: string }>({});
+  const [limit, setLimit] = useState(25);
+  const [currentPage, setCurrentPage] = useState(0);
+  const opts: IRunsListOpts = {
+    limit: limit,
+    cursor: mapPageToNextCursor.current[currentPage - 1],
+  };
   const { isLoading, data } = useWorkflowRunsList(opts, apiClient);
+
+  const handleChangePage = (_e: any, newPage: number) => {
+    // We have the cursor, we can allow the page transition.
+    if (newPage === 0 || mapPageToNextCursor.current[newPage - 1]) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  useEffect(() => {
+    const nc = data?.pagination?.nextCursor;
+    if (nc) {
+      mapPageToNextCursor.current[currentPage] = nc;
+    }
+  }, [data?.pagination?.nextCursor]);
+
+  const handleLimitChange = (limit: number) => {
+    // Reset page to make sure that going back works
+    setCurrentPage(0);
+    setLimit(limit);
+  };
 
   useEffect(() => {
     opts.limit = limit;
@@ -30,8 +57,10 @@ export default function WorkflowRunsList() {
           <Box sx={{ mt: 3 }}>
             {data?.result && (
               <WorkflowRunsListResults
+                page={currentPage}
+                handlePageChange={handleChangePage}
                 limit={limit}
-                setLimit={setLimit}
+                setLimit={handleLimitChange}
                 runs={data?.result}
               ></WorkflowRunsListResults>
             )}

--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -1,9 +1,53 @@
 "use client";
 
-import { Box, Container, Typography } from "@mui/material";
+import {
+  Box,
+  Container,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+} from "@mui/material";
 import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
+import { useAuth } from "@contexts/auth";
+import { useWorkflows } from "@lib/apiclient/workflows";
+import { useEffect, useState } from "react";
+import WithLoader from "@components/with-loader";
+import { usePathname, useRouter } from "next/navigation";
 
-export default function WorkflowRunsList() {
+export default function WorkflowRunsList({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | undefined };
+}) {
+  const { apiClient } = useAuth();
+  // Load workflows to enable filtering
+  const { isLoading: loadingWorkflows, data: workflows } =
+    useWorkflows(apiClient);
+
+  const [workflowID, setWorkflowID] = useState("");
+  const router = useRouter();
+  const currentPath = usePathname();
+
+  const handleWorkflowIDChange = (event: SelectChangeEvent) => {
+    const workflowID = event.target.value as string;
+    // TODO(miguel): find another way of doing this in the new router
+    // The query object doesn't seem to be available?
+    router.push(`${currentPath}?workflow=${workflowID}`);
+    setWorkflowID(workflowID);
+  };
+
+  // Load workflow from params
+  useEffect(() => {
+    const workflowID = searchParams && searchParams["workflow"];
+    if (!!workflowID) {
+      setWorkflowID(workflowID);
+    }
+  }, [searchParams]);
+
   return (
     <Box component="main" sx={{ flexGrow: 1 }}>
       <Container maxWidth={false}>
@@ -11,7 +55,30 @@ export default function WorkflowRunsList() {
           Workflow Runs
         </Typography>
         <Box sx={{ mt: 3 }}>
-          <WorkflowRunsListResults></WorkflowRunsListResults>
+          <WithLoader loading={loadingWorkflows}>
+            <Grid container justifyContent="right" pb="20px">
+              <Grid item xs={12} sm={6} lg={3} xl={2}>
+                <FormControl fullWidth>
+                  <InputLabel>Filter by Workflow</InputLabel>
+                  <Select
+                    value={workflowID}
+                    label="Workflow"
+                    onChange={handleWorkflowIDChange}
+                  >
+                    <MenuItem value="">Any</MenuItem>
+                    {workflows?.result.map((run) => (
+                      <MenuItem value={run.id} key={run.id}>
+                        {run.project}/{run.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+          </WithLoader>
+          <WorkflowRunsListResults
+            workflowID={workflowID}
+          ></WorkflowRunsListResults>
         </Box>
       </Container>
     </Box>

--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -8,12 +8,17 @@ import {
   useWorkflowRunsList,
 } from "@lib/apiclient/workflowRuns";
 import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
+import { useEffect, useState } from "react";
 
 export default function WorkflowRunsList() {
   const { apiClient } = useAuth();
-  // TODO(miguel): add filtering by workflow + pagination info
-  const opts: IRunsListOpts = {};
+  const [limit, setLimit] = useState(20);
+  const opts: IRunsListOpts = { limit: limit };
   const { isLoading, data } = useWorkflowRunsList(opts, apiClient);
+
+  useEffect(() => {
+    opts.limit = limit;
+  }, [limit]);
 
   return (
     <WithLoader loading={isLoading}>
@@ -25,6 +30,8 @@ export default function WorkflowRunsList() {
           <Box sx={{ mt: 3 }}>
             {data?.result && (
               <WorkflowRunsListResults
+                limit={limit}
+                setLimit={setLimit}
                 runs={data?.result}
               ></WorkflowRunsListResults>
             )}

--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@lib/apiclient/workflowRuns";
 import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
 import { useEffect, useRef, useState } from "react";
+import { useWorkflows } from "@lib/apiclient/workflows";
 
 export default function WorkflowRunsList() {
   const { apiClient } = useAuth();
@@ -17,11 +18,20 @@ export default function WorkflowRunsList() {
   const mapPageToNextCursor = useRef<{ [page: number]: string }>({});
   const [limit, setLimit] = useState(25);
   const [currentPage, setCurrentPage] = useState(0);
+  const [workflowID, setWorkflowID] = useState("");
   const opts: IRunsListOpts = {
     limit: limit,
+    workflowID: workflowID,
     cursor: mapPageToNextCursor.current[currentPage - 1],
   };
-  const { isLoading, data } = useWorkflowRunsList(opts, apiClient);
+  const { isLoading: loadingRuns, data: runs } = useWorkflowRunsList(
+    opts,
+    apiClient
+  );
+
+  // Load workflows to enable filtering
+  const { isLoading: loadingWorkflows, data: workflows } =
+    useWorkflows(apiClient);
 
   const handleChangePage = (_e: any, newPage: number) => {
     // We have the cursor, we can allow the page transition.
@@ -31,11 +41,11 @@ export default function WorkflowRunsList() {
   };
 
   useEffect(() => {
-    const nc = data?.pagination?.nextCursor;
+    const nc = runs?.pagination?.nextCursor;
     if (nc) {
       mapPageToNextCursor.current[currentPage] = nc;
     }
-  }, [data?.pagination?.nextCursor]);
+  }, [runs?.pagination?.nextCursor]);
 
   const handleLimitChange = (limit: number) => {
     // Reset page to make sure that going back works
@@ -48,20 +58,23 @@ export default function WorkflowRunsList() {
   }, [limit]);
 
   return (
-    <WithLoader loading={isLoading}>
+    <WithLoader loading={loadingRuns || loadingWorkflows}>
       <Box component="main" sx={{ flexGrow: 1 }}>
         <Container maxWidth={false}>
           <Typography sx={{ m: 1 }} variant="h4">
             Workflow Runs
           </Typography>
           <Box sx={{ mt: 3 }}>
-            {data?.result && (
+            {runs?.result && workflows?.result && (
               <WorkflowRunsListResults
                 page={currentPage}
+                workflowID={workflowID}
+                setWorkflowID={setWorkflowID}
                 handlePageChange={handleChangePage}
                 limit={limit}
                 setLimit={handleLimitChange}
-                runs={data?.result}
+                runs={runs?.result}
+                workflows={workflows?.result}
               ></WorkflowRunsListResults>
             )}
           </Box>

--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -1,85 +1,19 @@
 "use client";
 
-import { useAuth } from "@contexts/auth";
 import { Box, Container, Typography } from "@mui/material";
-import WithLoader from "@components/with-loader";
-import {
-  IRunsListOpts,
-  useWorkflowRunsList,
-} from "@lib/apiclient/workflowRuns";
 import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
-import { useEffect, useRef, useState } from "react";
-import { useWorkflows } from "@lib/apiclient/workflows";
 
 export default function WorkflowRunsList() {
-  const { apiClient } = useAuth();
-  // Store the cursor associated with the page
-  // Using useref to prevent re-rendering
-  const mapPageToNextCursor = useRef<{ [page: number]: string }>({});
-  const [limit, setLimit] = useState(25);
-  const [currentPage, setCurrentPage] = useState(0);
-  const [workflowID, setWorkflowID] = useState("");
-  const opts: IRunsListOpts = {
-    limit: limit,
-    workflowID: workflowID,
-    cursor: mapPageToNextCursor.current[currentPage - 1],
-  };
-  const { isLoading: loadingRuns, data: runs } = useWorkflowRunsList(
-    opts,
-    apiClient
-  );
-
-  // Load workflows to enable filtering
-  const { isLoading: loadingWorkflows, data: workflows } =
-    useWorkflows(apiClient);
-
-  const handleChangePage = (_e: any, newPage: number) => {
-    // We have the cursor, we can allow the page transition.
-    if (newPage === 0 || mapPageToNextCursor.current[newPage - 1]) {
-      setCurrentPage(newPage);
-    }
-  };
-
-  useEffect(() => {
-    const nc = runs?.pagination?.nextCursor;
-    if (nc) {
-      mapPageToNextCursor.current[currentPage] = nc;
-    }
-  }, [runs?.pagination?.nextCursor]);
-
-  const handleLimitChange = (limit: number) => {
-    // Reset page to make sure that going back works
-    setCurrentPage(0);
-    setLimit(limit);
-  };
-
-  useEffect(() => {
-    opts.limit = limit;
-  }, [limit]);
-
   return (
-    <WithLoader loading={loadingRuns || loadingWorkflows}>
-      <Box component="main" sx={{ flexGrow: 1 }}>
-        <Container maxWidth={false}>
-          <Typography sx={{ m: 1 }} variant="h4">
-            Workflow Runs
-          </Typography>
-          <Box sx={{ mt: 3 }}>
-            {runs?.result && workflows?.result && (
-              <WorkflowRunsListResults
-                page={currentPage}
-                workflowID={workflowID}
-                setWorkflowID={setWorkflowID}
-                handlePageChange={handleChangePage}
-                limit={limit}
-                setLimit={handleLimitChange}
-                runs={runs?.result}
-                workflows={workflows?.result}
-              ></WorkflowRunsListResults>
-            )}
-          </Box>
-        </Container>
-      </Box>
-    </WithLoader>
+    <Box component="main" sx={{ flexGrow: 1 }}>
+      <Container maxWidth={false}>
+        <Typography sx={{ m: 1 }} variant="h4">
+          Workflow Runs
+        </Typography>
+        <Box sx={{ mt: 3 }}>
+          <WorkflowRunsListResults></WorkflowRunsListResults>
+        </Box>
+      </Container>
+    </Box>
   );
 }

--- a/app/dashboard/workflow-runs/page.tsx
+++ b/app/dashboard/workflow-runs/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useAuth } from "@contexts/auth";
+import { Box, Container, Typography } from "@mui/material";
+import WithLoader from "@components/with-loader";
+import {
+  IRunsListOpts,
+  useWorkflowRunsList,
+} from "@lib/apiclient/workflowRuns";
+import { WorkflowRunsListResults } from "@components/workflow-runs-list/result/result";
+
+export default function WorkflowRunsList() {
+  const { apiClient } = useAuth();
+  // TODO(miguel): add filtering by workflow + pagination info
+  const opts: IRunsListOpts = {};
+  const { isLoading, data } = useWorkflowRunsList(opts, apiClient);
+
+  return (
+    <WithLoader loading={isLoading}>
+      <Box component="main" sx={{ flexGrow: 1 }}>
+        <Container maxWidth={false}>
+          <Typography sx={{ m: 1 }} variant="h4">
+            Workflow Runs
+          </Typography>
+          <Box sx={{ mt: 3 }}>
+            {data?.result && (
+              <WorkflowRunsListResults
+                runs={data?.result}
+              ></WorkflowRunsListResults>
+            )}
+          </Box>
+        </Container>
+      </Box>
+    </WithLoader>
+  );
+}

--- a/components/dashboard-sidebar/dashboard-sidebar.js
+++ b/components/dashboard-sidebar/dashboard-sidebar.js
@@ -11,7 +11,8 @@ import {
   Link as MaterialLink,
 } from "@mui/material";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import { Users as UsersIcon } from "../../icons/users";
+import DonutLargeIcon from "@mui/icons-material/DonutLarge";
+import ListAltIcon from "@mui/icons-material/ListAlt";
 import AllInclusiveIcon from "@mui/icons-material/AllInclusive";
 import NavItem from "../nav-item";
 import { useEffect } from "react";
@@ -19,8 +20,13 @@ import { useEffect } from "react";
 const items = [
   {
     href: "/dashboard/workflows",
-    icon: <UsersIcon fontSize="small" />,
+    icon: <ListAltIcon fontSize="small" />,
     title: "Workflows",
+  },
+  {
+    href: "/dashboard/workflow-runs",
+    icon: <DonutLargeIcon fontSize="small" />,
+    title: "Workflow Runs",
   },
 ];
 

--- a/components/workflow-list/result/results.tsx
+++ b/components/workflow-list/result/results.tsx
@@ -9,7 +9,6 @@ import {
   Typography,
 } from "@mui/material";
 import { WorkflowItem } from "@pb/controlplane/v1/response_messages";
-import Link from "next/link";
 import { Box } from "@mui/system";
 import { formatDistanceToNow } from "date-fns";
 import WorkflowRunStatus from "../../workflow-view/workflow-runs/detail/run-status";

--- a/components/workflow-list/toolbar/toolbar.tsx
+++ b/components/workflow-list/toolbar/toolbar.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 
 export const WorkflowListToolbar = () => (
   <Box>

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -9,8 +9,17 @@ import {
   TableCell,
   TableBody,
   TablePagination,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Grid,
+  SelectChangeEvent,
 } from "@mui/material";
-import { WorkflowRunItem } from "@pb/controlplane/v1/response_messages";
+import {
+  WorkflowItem,
+  WorkflowRunItem,
+} from "@pb/controlplane/v1/response_messages";
 import { format } from "date-fns";
 
 export const WorkflowRunsListResults = ({
@@ -18,12 +27,18 @@ export const WorkflowRunsListResults = ({
   limit,
   setLimit,
   handlePageChange,
+  setWorkflowID,
   page,
+  workflowID,
+  workflows,
 }: {
   runs: WorkflowRunItem[];
+  workflows: WorkflowItem[];
+  workflowID: string;
   limit: number;
   page: number;
   setLimit: (_limit: number) => void;
+  setWorkflowID: (_wf: string) => void;
   handlePageChange: (_e: unknown, _page: number) => void;
 }) => {
   const handleChangeRowsPerPage = (
@@ -32,8 +47,31 @@ export const WorkflowRunsListResults = ({
     setLimit(parseInt(event.target.value, 10));
   };
 
+  const handleWorkflowIDChange = (event: SelectChangeEvent) => {
+    setWorkflowID(event.target.value as string);
+  };
+
   return (
     <>
+      <Grid container justifyContent="right" pb="20px">
+        <Grid item xs={12} sm={3} xl={2}>
+          <FormControl fullWidth>
+            <InputLabel>Filter by Workflow</InputLabel>
+            <Select
+              value={workflowID}
+              label="Workflow"
+              onChange={handleWorkflowIDChange}
+            >
+              <MenuItem value="">Any</MenuItem>
+              {workflows?.map((run) => (
+                <MenuItem value={run.id} key={run.id}>
+                  {run.project}/{run.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
       <TableContainer component={Paper}>
         <Table>
           <TableHead>

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -17,15 +17,15 @@ export const WorkflowRunsListResults = ({
   runs,
   limit,
   setLimit,
+  handlePageChange,
+  page,
 }: {
   runs: WorkflowRunItem[];
   limit: number;
-  setLimit: (_: number) => void;
+  page: number;
+  setLimit: (_limit: number) => void;
+  handlePageChange: (_e: unknown, _page: number) => void;
 }) => {
-  const handleChangePage = (event: unknown, newPage: number) => {
-    console.log(newPage);
-  };
-
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -63,12 +63,12 @@ export const WorkflowRunsListResults = ({
         </Table>
       </TableContainer>
       <TablePagination
-        rowsPerPageOptions={[20, 50, 100]}
+        rowsPerPageOptions={[25, 50, 100]}
         rowsPerPage={limit}
         component="div"
         count={-1}
-        page={0}
-        onPageChange={handleChangePage}
+        page={page}
+        onPageChange={handlePageChange}
         onRowsPerPageChange={handleChangeRowsPerPage}
       />
     </>

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -1,5 +1,12 @@
+import WithLoader from "@components/with-loader";
 import WorkflowRunStatus from "@components/workflow-view/workflow-runs/detail/run-status";
 import { IStatus } from "@components/workflow-view/workflow-runs/detail/run-status/run-status";
+import { useAuth } from "@contexts/auth";
+import {
+  IRunsListOpts,
+  useWorkflowRunsList,
+} from "@lib/apiclient/workflowRuns";
+import { useWorkflows } from "@lib/apiclient/workflows";
 import {
   TableContainer,
   Paper,
@@ -16,99 +23,132 @@ import {
   Grid,
   SelectChangeEvent,
 } from "@mui/material";
-import {
-  WorkflowItem,
-  WorkflowRunItem,
-} from "@pb/controlplane/v1/response_messages";
 import { format } from "date-fns";
+import { useEffect, useRef, useState } from "react";
 
-export const WorkflowRunsListResults = ({
-  runs,
-  limit,
-  setLimit,
-  handlePageChange,
-  setWorkflowID,
-  page,
-  workflowID,
-  workflows,
-}: {
-  runs: WorkflowRunItem[];
-  workflows: WorkflowItem[];
-  workflowID: string;
-  limit: number;
-  page: number;
-  setLimit: (_limit: number) => void;
-  setWorkflowID: (_wf: string) => void;
-  handlePageChange: (_e: unknown, _page: number) => void;
-}) => {
+export const WorkflowRunsListResults = ({}: {}) => {
+  const { apiClient } = useAuth();
+  const mapPageToNextCursor = useRef<{ [page: number]: string }>({});
+  const [limit, setLimit] = useState(25);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [page, setCurrentPage] = useState(0);
+  const [workflowID, setWorkflowID] = useState("");
+
+  // Load data
+  const opts: IRunsListOpts = {
+    limit: limit,
+    workflowID: workflowID,
+    cursor: mapPageToNextCursor.current[page - 1],
+  };
+  const { isLoading: loadingRuns, data: runs } = useWorkflowRunsList(
+    opts,
+    apiClient
+  );
+
+  // Load workflows to enable filtering
+  const { isLoading: loadingWorkflows, data: workflows } =
+    useWorkflows(apiClient);
+
+  // Define handlers
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setLimit(parseInt(event.target.value, 10));
+    const newLimit = parseInt(event.target.value, 10);
+    resetTable();
+    setLimit(newLimit);
+  };
+
+  const resetTable = () => {
+    setCurrentPage(0);
+    mapPageToNextCursor.current = {};
   };
 
   const handleWorkflowIDChange = (event: SelectChangeEvent) => {
+    resetTable();
     setWorkflowID(event.target.value as string);
   };
 
+  const handlePageChange = (_e: any, newPage: number) => {
+    // We have the cursor, we can allow the page transition.
+    if (newPage === 0 || mapPageToNextCursor.current[newPage - 1]) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  // Keep track of the cursors associated with the different pages
+  useEffect(() => {
+    const nc = runs?.pagination?.nextCursor;
+    if (nc) {
+      mapPageToNextCursor.current[page] = nc;
+      setHasNextPage(true);
+    } else {
+      setHasNextPage(false);
+    }
+  }, [runs?.pagination?.nextCursor]);
+
   return (
     <>
-      <Grid container justifyContent="right" pb="20px">
-        <Grid item xs={12} sm={3} xl={2}>
-          <FormControl fullWidth>
-            <InputLabel>Filter by Workflow</InputLabel>
-            <Select
-              value={workflowID}
-              label="Workflow"
-              onChange={handleWorkflowIDChange}
-            >
-              <MenuItem value="">Any</MenuItem>
-              {workflows?.map((run) => (
-                <MenuItem value={run.id} key={run.id}>
-                  {run.project}/{run.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+      <WithLoader loading={loadingRuns || loadingWorkflows}>
+        <Grid container justifyContent="right" pb="20px">
+          <Grid item xs={12} sm={6} lg={3} xl={2}>
+            <FormControl fullWidth>
+              <InputLabel>Filter by Workflow</InputLabel>
+              <Select
+                value={workflowID}
+                label="Workflow"
+                onChange={handleWorkflowIDChange}
+              >
+                <MenuItem value="">Any</MenuItem>
+                {workflows?.result.map((run) => (
+                  <MenuItem value={run.id} key={run.id}>
+                    {run.project}/{run.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
         </Grid>
-      </Grid>
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Project</TableCell>
-              <TableCell>Team</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Started</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {runs?.map((run) => (
-              <TableRow hover key={run.id} sx={{ cursor: "pointer" }}>
-                <TableCell>{run.workflow!.name}</TableCell>
-                <TableCell>{run.workflow!.project}</TableCell>
-                <TableCell>{run.workflow!.team}</TableCell>
-                <TableCell>
-                  <WorkflowRunStatus
-                    status={run.state as IStatus}
-                  ></WorkflowRunStatus>
-                </TableCell>
-                <TableCell>{format(run?.createdAt!, "Pp")}</TableCell>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Project</TableCell>
+                <TableCell>Team</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Started</TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <TablePagination
-        rowsPerPageOptions={[25, 50, 100]}
-        rowsPerPage={limit}
-        component="div"
-        count={-1}
-        page={page}
-        onPageChange={handlePageChange}
-        onRowsPerPageChange={handleChangeRowsPerPage}
-      />
+            </TableHead>
+            <TableBody>
+              {runs?.result.map((run) => (
+                <TableRow hover key={run.id} sx={{ cursor: "pointer" }}>
+                  <TableCell>{run.workflow!.name}</TableCell>
+                  <TableCell>{run.workflow!.project}</TableCell>
+                  <TableCell>{run.workflow!.team}</TableCell>
+                  <TableCell>
+                    <WorkflowRunStatus
+                      status={run.state as IStatus}
+                    ></WorkflowRunStatus>
+                  </TableCell>
+                  <TableCell>{format(run?.createdAt!, "Pp")}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[25, 50, 100]}
+          rowsPerPage={limit}
+          component="div"
+          count={-1}
+          page={page}
+          nextIconButtonProps={{
+            disabled: !hasNextPage,
+          }}
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </WithLoader>
     </>
   );
 };

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -1,0 +1,49 @@
+import WorkflowRunStatus from "@components/workflow-view/workflow-runs/detail/run-status";
+import { IStatus } from "@components/workflow-view/workflow-runs/detail/run-status/run-status";
+import {
+  TableContainer,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from "@mui/material";
+import { WorkflowRunItem } from "@pb/controlplane/v1/response_messages";
+
+export const WorkflowRunsListResults = ({
+  runs,
+}: {
+  runs: WorkflowRunItem[];
+}) => {
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Project</TableCell>
+            <TableCell>Team</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Created at</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {runs?.map((run) => (
+            <TableRow hover key={run.id} sx={{ cursor: "pointer" }}>
+              <TableCell>{run.workflow!.name}</TableCell>
+              <TableCell>{run.workflow!.project}</TableCell>
+              <TableCell>{run.workflow!.team}</TableCell>
+              <TableCell>
+                <WorkflowRunStatus
+                  status={run.state as IStatus}
+                ></WorkflowRunStatus>
+              </TableCell>
+              <TableCell>{run.createdAt?.toDateString()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -8,42 +8,69 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TablePagination,
 } from "@mui/material";
 import { WorkflowRunItem } from "@pb/controlplane/v1/response_messages";
+import { format } from "date-fns";
 
 export const WorkflowRunsListResults = ({
   runs,
+  limit,
+  setLimit,
 }: {
   runs: WorkflowRunItem[];
+  limit: number;
+  setLimit: (_: number) => void;
 }) => {
+  const handleChangePage = (event: unknown, newPage: number) => {
+    console.log(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setLimit(parseInt(event.target.value, 10));
+  };
+
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Project</TableCell>
-            <TableCell>Team</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Created at</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {runs?.map((run) => (
-            <TableRow hover key={run.id} sx={{ cursor: "pointer" }}>
-              <TableCell>{run.workflow!.name}</TableCell>
-              <TableCell>{run.workflow!.project}</TableCell>
-              <TableCell>{run.workflow!.team}</TableCell>
-              <TableCell>
-                <WorkflowRunStatus
-                  status={run.state as IStatus}
-                ></WorkflowRunStatus>
-              </TableCell>
-              <TableCell>{run.createdAt?.toDateString()}</TableCell>
+    <>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Project</TableCell>
+              <TableCell>Team</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Started</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          </TableHead>
+          <TableBody>
+            {runs?.map((run) => (
+              <TableRow hover key={run.id} sx={{ cursor: "pointer" }}>
+                <TableCell>{run.workflow!.name}</TableCell>
+                <TableCell>{run.workflow!.project}</TableCell>
+                <TableCell>{run.workflow!.team}</TableCell>
+                <TableCell>
+                  <WorkflowRunStatus
+                    status={run.state as IStatus}
+                  ></WorkflowRunStatus>
+                </TableCell>
+                <TableCell>{format(run?.createdAt!, "Pp")}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[20, 50, 100]}
+        rowsPerPage={limit}
+        component="div"
+        count={-1}
+        page={0}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </>
   );
 };

--- a/components/workflow-runs-list/result/result.tsx
+++ b/components/workflow-runs-list/result/result.tsx
@@ -6,7 +6,6 @@ import {
   IRunsListOpts,
   useWorkflowRunsList,
 } from "@lib/apiclient/workflowRuns";
-import { useWorkflows } from "@lib/apiclient/workflows";
 import {
   TableContainer,
   Paper,
@@ -16,23 +15,20 @@ import {
   TableCell,
   TableBody,
   TablePagination,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Grid,
-  SelectChangeEvent,
 } from "@mui/material";
 import { format } from "date-fns";
 import { useEffect, useRef, useState } from "react";
 
-export const WorkflowRunsListResults = ({}: {}) => {
+export const WorkflowRunsListResults = ({
+  workflowID,
+}: {
+  workflowID: string;
+}) => {
   const { apiClient } = useAuth();
   const mapPageToNextCursor = useRef<{ [page: number]: string }>({});
   const [limit, setLimit] = useState(25);
   const [hasNextPage, setHasNextPage] = useState(false);
   const [page, setCurrentPage] = useState(0);
-  const [workflowID, setWorkflowID] = useState("");
 
   // Load data
   const opts: IRunsListOpts = {
@@ -45,16 +41,11 @@ export const WorkflowRunsListResults = ({}: {}) => {
     apiClient
   );
 
-  // Load workflows to enable filtering
-  const { isLoading: loadingWorkflows, data: workflows } =
-    useWorkflows(apiClient);
-
   // Define handlers
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     const newLimit = parseInt(event.target.value, 10);
-    resetTable();
     setLimit(newLimit);
   };
 
@@ -63,10 +54,9 @@ export const WorkflowRunsListResults = ({}: {}) => {
     mapPageToNextCursor.current = {};
   };
 
-  const handleWorkflowIDChange = (event: SelectChangeEvent) => {
+  useEffect(() => {
     resetTable();
-    setWorkflowID(event.target.value as string);
-  };
+  }, [workflowID, limit]);
 
   const handlePageChange = (_e: any, newPage: number) => {
     // We have the cursor, we can allow the page transition.
@@ -88,26 +78,7 @@ export const WorkflowRunsListResults = ({}: {}) => {
 
   return (
     <>
-      <WithLoader loading={loadingRuns || loadingWorkflows}>
-        <Grid container justifyContent="right" pb="20px">
-          <Grid item xs={12} sm={6} lg={3} xl={2}>
-            <FormControl fullWidth>
-              <InputLabel>Filter by Workflow</InputLabel>
-              <Select
-                value={workflowID}
-                label="Workflow"
-                onChange={handleWorkflowIDChange}
-              >
-                <MenuItem value="">Any</MenuItem>
-                {workflows?.result.map((run) => (
-                  <MenuItem value={run.id} key={run.id}>
-                    {run.project}/{run.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-        </Grid>
+      <WithLoader loading={loadingRuns}>
         <TableContainer component={Paper}>
           <Table>
             <TableHead>

--- a/components/workflow-view/summary/summary.tsx
+++ b/components/workflow-view/summary/summary.tsx
@@ -1,5 +1,4 @@
 import { Typography, Card, CardContent, Grid } from "@mui/material";
-import WorkflowRunStatus from "../workflow-runs/detail/run-status";
 import { WorkflowItem } from "@pb/controlplane/v1/response_messages";
 
 export const WorkflowSummary = ({ wf }: { wf: WorkflowItem }) => {

--- a/components/workflow-view/workflow-runs/list-sidebar/list-sidebar.tsx
+++ b/components/workflow-view/workflow-runs/list-sidebar/list-sidebar.tsx
@@ -18,7 +18,7 @@ export const RunsListSidebar = ({
   onSelect,
 }: {
   runs: WorkflowRunItem[];
-  onSelect: (s: string) => void;
+  onSelect: (_: string) => void;
 }) => {
   const [currentRun, setCurrentRun] = useState("");
 

--- a/components/workflow-view/workflow-runs/workflow-runs.tsx
+++ b/components/workflow-view/workflow-runs/workflow-runs.tsx
@@ -10,13 +10,17 @@ import { useState } from "react";
 import RunsListSidebar from "./list-sidebar";
 import RunDetail from "./detail";
 import { useAuth } from "@contexts/auth";
-import { useWorkflowRunsList } from "@lib/apiclient/workflowRuns";
+import {
+  IRunsListOpts,
+  useWorkflowRunsList,
+} from "@lib/apiclient/workflowRuns";
 import WithLoader from "../../with-loader";
 
 export const WorkflowRuns = ({ workflowID }: { workflowID: string }) => {
   const [currentRunID, setCurrentRunID] = useState("");
   const { apiClient } = useAuth();
-  const { isLoading, data } = useWorkflowRunsList(workflowID, apiClient);
+  const opts: IRunsListOpts = { workflowID: workflowID };
+  const { isLoading, data } = useWorkflowRunsList(opts, apiClient);
 
   return (
     <Card raised>

--- a/gen/controlplane/v1/pagination.ts
+++ b/gen/controlplane/v1/pagination.ts
@@ -5,61 +5,22 @@ export const protobufPackage = "controlplane.v1";
 
 export interface PaginationResponse {
   nextCursor: string;
-  prevCursor: string;
 }
 
 export interface PaginationRequest {
   cursor: string;
-  direction: PaginationRequest_Direction;
   /** Limit pagination to 100 */
   limit: number;
 }
 
-/** nolint:ENUM_VALUE_PREFIX */
-export enum PaginationRequest_Direction {
-  DIRECTION_NEXT_PAGE = 0,
-  DIRECTION_PREV_PAGE = 1,
-  UNRECOGNIZED = -1,
-}
-
-export function paginationRequest_DirectionFromJSON(object: any): PaginationRequest_Direction {
-  switch (object) {
-    case 0:
-    case "DIRECTION_NEXT_PAGE":
-      return PaginationRequest_Direction.DIRECTION_NEXT_PAGE;
-    case 1:
-    case "DIRECTION_PREV_PAGE":
-      return PaginationRequest_Direction.DIRECTION_PREV_PAGE;
-    case -1:
-    case "UNRECOGNIZED":
-    default:
-      return PaginationRequest_Direction.UNRECOGNIZED;
-  }
-}
-
-export function paginationRequest_DirectionToJSON(object: PaginationRequest_Direction): string {
-  switch (object) {
-    case PaginationRequest_Direction.DIRECTION_NEXT_PAGE:
-      return "DIRECTION_NEXT_PAGE";
-    case PaginationRequest_Direction.DIRECTION_PREV_PAGE:
-      return "DIRECTION_PREV_PAGE";
-    case PaginationRequest_Direction.UNRECOGNIZED:
-    default:
-      return "UNRECOGNIZED";
-  }
-}
-
 function createBasePaginationResponse(): PaginationResponse {
-  return { nextCursor: "", prevCursor: "" };
+  return { nextCursor: "" };
 }
 
 export const PaginationResponse = {
   encode(message: PaginationResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.nextCursor !== "") {
       writer.uint32(10).string(message.nextCursor);
-    }
-    if (message.prevCursor !== "") {
-      writer.uint32(18).string(message.prevCursor);
     }
     return writer;
   },
@@ -74,9 +35,6 @@ export const PaginationResponse = {
         case 1:
           message.nextCursor = reader.string();
           break;
-        case 2:
-          message.prevCursor = reader.string();
-          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -86,38 +44,30 @@ export const PaginationResponse = {
   },
 
   fromJSON(object: any): PaginationResponse {
-    return {
-      nextCursor: isSet(object.nextCursor) ? String(object.nextCursor) : "",
-      prevCursor: isSet(object.prevCursor) ? String(object.prevCursor) : "",
-    };
+    return { nextCursor: isSet(object.nextCursor) ? String(object.nextCursor) : "" };
   },
 
   toJSON(message: PaginationResponse): unknown {
     const obj: any = {};
     message.nextCursor !== undefined && (obj.nextCursor = message.nextCursor);
-    message.prevCursor !== undefined && (obj.prevCursor = message.prevCursor);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<PaginationResponse>, I>>(object: I): PaginationResponse {
     const message = createBasePaginationResponse();
     message.nextCursor = object.nextCursor ?? "";
-    message.prevCursor = object.prevCursor ?? "";
     return message;
   },
 };
 
 function createBasePaginationRequest(): PaginationRequest {
-  return { cursor: "", direction: 0, limit: 0 };
+  return { cursor: "", limit: 0 };
 }
 
 export const PaginationRequest = {
   encode(message: PaginationRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.cursor !== "") {
       writer.uint32(10).string(message.cursor);
-    }
-    if (message.direction !== 0) {
-      writer.uint32(16).int32(message.direction);
     }
     if (message.limit !== 0) {
       writer.uint32(24).int32(message.limit);
@@ -135,9 +85,6 @@ export const PaginationRequest = {
         case 1:
           message.cursor = reader.string();
           break;
-        case 2:
-          message.direction = reader.int32() as any;
-          break;
         case 3:
           message.limit = reader.int32();
           break;
@@ -152,7 +99,6 @@ export const PaginationRequest = {
   fromJSON(object: any): PaginationRequest {
     return {
       cursor: isSet(object.cursor) ? String(object.cursor) : "",
-      direction: isSet(object.direction) ? paginationRequest_DirectionFromJSON(object.direction) : 0,
       limit: isSet(object.limit) ? Number(object.limit) : 0,
     };
   },
@@ -160,7 +106,6 @@ export const PaginationRequest = {
   toJSON(message: PaginationRequest): unknown {
     const obj: any = {};
     message.cursor !== undefined && (obj.cursor = message.cursor);
-    message.direction !== undefined && (obj.direction = paginationRequest_DirectionToJSON(message.direction));
     message.limit !== undefined && (obj.limit = Math.round(message.limit));
     return obj;
   },
@@ -168,7 +113,6 @@ export const PaginationRequest = {
   fromPartial<I extends Exact<DeepPartial<PaginationRequest>, I>>(object: I): PaginationRequest {
     const message = createBasePaginationRequest();
     message.cursor = object.cursor ?? "";
-    message.direction = object.direction ?? 0;
     message.limit = object.limit ?? 0;
     return message;
   },

--- a/lib/apiclient/workflowRuns.ts
+++ b/lib/apiclient/workflowRuns.ts
@@ -14,7 +14,8 @@ export function useWorkflowRunsList(opts: IRunsListOpts, client: ApiClient | und
   const shouldFetch = client != undefined
 
   // Arbitrary caching key
-  const fetchKey = ["workflow-runs", opts.workflowID, opts.limit, opts.nextCursor, opts.PrevCursor].join("-")
+  var fetchKey = ["workflow-runs", opts.workflowID, opts.limit, opts.nextCursor, opts.PrevCursor].join("-")
+  console.log(fetchKey)
 
   const { data, error } = useSWR(shouldFetch ? fetchKey : null, (_: string) => getWorkflowRuns(opts, client!))
   return swrResp(data, error)

--- a/lib/apiclient/workflowRuns.ts
+++ b/lib/apiclient/workflowRuns.ts
@@ -1,16 +1,54 @@
 import useSWR from 'swr'
 import ApiClient, { swrResp } from "./client";
-import { WorkflowRunServiceClientImpl, WorkflowRunServiceListResponse, WorkflowRunServiceViewResponse } from '@pb/controlplane/v1/workflowrun';
+import { WorkflowRunServiceClientImpl, WorkflowRunServiceListRequest, WorkflowRunServiceListResponse, WorkflowRunServiceViewResponse } from '@pb/controlplane/v1/workflowrun';
+import { PaginationRequest, PaginationRequest_Direction } from '@pb/controlplane/v1/pagination';
 
-export function useWorkflowRunsList(workflowID: string, client: ApiClient | undefined) {
+export interface IRunsListOpts {
+  workflowID?: string
+  limit?: number
+  nextCursor?: string
+  PrevCursor?: string
+}
+
+export function useWorkflowRunsList(opts: IRunsListOpts, client: ApiClient | undefined) {
   const shouldFetch = client != undefined
-  const { data, error } = useSWR(shouldFetch ? ["workflow-runs", workflowID] : null, (_: string) => getWorkflowRuns(workflowID, client!))
+
+  // Arbitrary caching key
+  const fetchKey = ["workflow-runs", opts.workflowID, opts.limit, opts.nextCursor, opts.PrevCursor].join("-")
+
+  const { data, error } = useSWR(shouldFetch ? fetchKey : null, (_: string) => getWorkflowRuns(opts, client!))
   return swrResp(data, error)
 }
 
-function getWorkflowRuns(workflowID: string, apiClient: ApiClient): Promise<WorkflowRunServiceListResponse> {
+function getWorkflowRuns(opts: IRunsListOpts, apiClient: ApiClient): Promise<WorkflowRunServiceListResponse> {
   var client = new WorkflowRunServiceClientImpl(apiClient.grpcClient)
-  return client.List({ workflowId: workflowID })
+  const payload: Partial<WorkflowRunServiceListRequest> = {}
+
+  // filter options
+  if (opts.workflowID) {
+    payload.workflowId = opts.workflowID
+  }
+
+  // pagination options
+  const pageRequest: Partial<PaginationRequest> = {
+    direction: PaginationRequest_Direction.DIRECTION_NEXT_PAGE,
+    cursor: ""
+  }
+
+  if (opts.limit) {
+    pageRequest.limit = opts.limit
+  }
+
+  if (opts.nextCursor) {
+    pageRequest.cursor = opts.nextCursor
+  } else if (opts.PrevCursor) {
+    pageRequest.cursor = opts.PrevCursor
+    pageRequest.direction = PaginationRequest_Direction.DIRECTION_PREV_PAGE
+  }
+
+  payload.pagination = pageRequest as PaginationRequest
+
+  return client.List(payload)
 }
 
 export function useWorkflowRunDescribe(runID: string, client: ApiClient | undefined) {

--- a/lib/apiclient/workflowRuns.ts
+++ b/lib/apiclient/workflowRuns.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
 import ApiClient, { swrResp } from "./client";
 import { WorkflowRunServiceClientImpl, WorkflowRunServiceListRequest, WorkflowRunServiceListResponse, WorkflowRunServiceViewResponse } from '@pb/controlplane/v1/workflowrun';
-import { PaginationRequest, PaginationRequest_Direction } from '@pb/controlplane/v1/pagination';
+import { PaginationRequest } from '@pb/controlplane/v1/pagination';
 
 export type IRunsListDirection = "next_page" | "prev_page"
 export interface IRunsListOpts {
@@ -31,7 +31,6 @@ function getWorkflowRuns(opts: IRunsListOpts, apiClient: ApiClient): Promise<Wor
 
   // pagination options
   const pageRequest: PaginationRequest = {
-    direction: PaginationRequest_Direction.DIRECTION_NEXT_PAGE,
     cursor: opts.cursor || "",
     limit: 0,
   }


### PR DESCRIPTION
Paginated global/org-wide workflow Runs list with the following properties

* The number of items per page can be configured
* Results can be filtered by workflow, creating a permalink that will be linked from the workflow view next.

NOTE: There is no standalone workflowrun view yet. I'll be adding that one next and linked from here.

![pagination](https://user-images.githubusercontent.com/24523/205048800-483b5bb5-906e-4f5b-9bf8-59be950922e2.gif)

Refs #15 