### PR TITLE
chore(ci): bump chainLoop client version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   release:
     env:
-      CL_VERSION: 0.8.46
+      CL_VERSION: 0.8.48
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}
     name: Release Frontend Container Image
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,5 @@ jobs:
           chainloop attestation reset --trigger cancellation
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CL_VERSION: 0.8.29
+      CL_VERSION: 0.8.48
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_BUILD_AND_TEST }}


### PR DESCRIPTION
The latest [ci errors](https://github.com/chainloop-dev/frontend/actions/runs/3731905970/jobs/6337337090) were due a deprecation in the control-plane that required CLI upgrade. 